### PR TITLE
feat(core): modify exception handler test cases

### DIFF
--- a/packages/core/test/errors/test/exception-handler.spec.ts
+++ b/packages/core/test/errors/test/exception-handler.spec.ts
@@ -2,7 +2,7 @@ import * as sinon from 'sinon';
 import { expect } from 'chai';
 import { ExceptionHandler } from '../../../errors/exception-handler';
 import { RuntimeException } from '../../../errors/exceptions/runtime.exception';
-import { InvalidMiddlewareException } from '../../../errors/exceptions/invalid-middleware.exception';
+import { combineStackTrace } from '../../../helpers/combine-stack-trace';
 
 describe('ExceptionHandler', () => {
   let instance: ExceptionHandler;
@@ -22,13 +22,16 @@ describe('ExceptionHandler', () => {
     it('when exception is instanceof RuntimeException', () => {
       const exception = new RuntimeException('msg');
       instance.handle(exception);
-      expect(errorSpy.calledWith(exception.message, exception.stack)).to.be
-        .true;
+      expect(
+        errorSpy.calledWith(exception.what(), combineStackTrace(exception)),
+      ).to.be.true;
     });
     it('when exception is not instanceof RuntimeException', () => {
-      const exception = new InvalidMiddlewareException('msg');
+      const exception = new Error('msg');
       instance.handle(exception);
-      expect(errorSpy.calledWith(exception.what(), exception.stack)).to.be.true;
+      expect(
+        errorSpy.calledWith(exception.message, combineStackTrace(exception)),
+      ).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #13550 #13870

## What is the new behavior?

It appears that the current exception-handler test cases do not utilize the updated `combineStackTrace` function.

```typescript
it('when exception is instanceof RuntimeException', () => {
  const exception = new RuntimeException('msg');
  instance.handle(exception);
  expect(errorSpy.calledWith(exception.message, exception.stack)).to.be
    .true;
});
```

After reviewing the PR, I noticed that in cases where the exception is a `RuntimeException`, the `ExceptionHandler.logger.error` method uses `combineStackTrace(exception)` as the second parameter.

```typescript
public handle(exception: RuntimeException | Error) {
  if (!(exception instanceof RuntimeException)) {
    ExceptionHandler.logger.error(
      exception.message,
      combineStackTrace(exception),
    );
    return;
  }
  ExceptionHandler.logger.error(
    exception.what(),
    combineStackTrace(exception),
  );
}
```

To align with this change, I have made some modifications to the related test code and am submitting this PR. Please review the changes.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information